### PR TITLE
FIX: Do not show status badge for private repo

### DIFF
--- a/javascripts/discourse/initializers/initialize-github-status.js
+++ b/javascripts/discourse/initializers/initialize-github-status.js
@@ -23,6 +23,13 @@ export default {
         return;
       }
 
+      const isPrivate =
+        onebox.querySelector(".onebox-body .github-row")?.dataset
+          .githubPrivateRepo === "true";
+      if (isPrivate) {
+        return;
+      }
+
       const href = link.getAttribute("href");
       const parts = href.match(
         /https:\/\/github\.com\/([\w-]+)\/([\w-]+)\/(pull|issues)\/(\d+)/


### PR DESCRIPTION
There is no support for fetching a private repo PR/issue
badge from https://shields.io/, so in the case of a private
repo (which we indicate with a data attr in the core commit
https://github.com/discourse/discourse/commit/f5cbc3e3b8a58132fc835aeab4d2275719ebe8ab)
we simply do not show a status badge.
